### PR TITLE
Updated Firewall Rules

### DIFF
--- a/ansible/roles/base-os/files/ntp.conf
+++ b/ansible/roles/base-os/files/ntp.conf
@@ -1,0 +1,55 @@
+# For more information about this file, see the man pages
+# ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).
+
+driftfile /var/lib/ntp/drift
+
+# Permit time synchronization with our time source, but do not
+# permit the source to query or modify the service on this system.
+restrict default nomodify notrap nopeer noquery
+
+# Permit all access over the loopback interface.  This could
+# be tightened as well, but to do so would effect some of
+# the administrative functions.
+restrict 127.0.0.1 
+restrict ::1
+
+# Hosts on local network are less restricted.
+#restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 66.199.22.67 prefer
+
+#broadcast 192.168.1.255 autokey	# broadcast server
+#broadcastclient			# broadcast client
+#broadcast 224.0.1.1 autokey		# multicast server
+#multicastclient 224.0.1.1		# multicast client
+#manycastserver 239.255.254.254		# manycast server
+#manycastclient 239.255.254.254 autokey # manycast client
+
+# Enable public key cryptography.
+#crypto
+
+includefile /etc/ntp/crypto/pw
+
+# Key file containing the keys and key identifiers used when operating
+# with symmetric key cryptography. 
+keys /etc/ntp/keys
+
+# Specify the key identifiers which are trusted.
+#trustedkey 4 8 42
+
+# Specify the key identifier to use with the ntpdc utility.
+#requestkey 8
+
+# Specify the key identifier to use with the ntpq utility.
+#controlkey 8
+
+# Enable writing of statistics records.
+#statistics clockstats cryptostats loopstats peerstats
+
+# Disable the monitoring facility to prevent amplification attacks using ntpdc
+# monlist command when default restrict does not include the noquery flag. See
+# CVE-2013-5211 for more details.
+# Note: Monitoring will not be disabled with the limited restriction flag.
+disable monitor

--- a/ansible/roles/base-os/tasks/main.yml
+++ b/ansible/roles/base-os/tasks/main.yml
@@ -30,7 +30,6 @@
 - name: Enable NTP on Startup
   service: name=ntpd state=started enabled=yes
 
-# This step required server reboot to take full effect. Why?
 - name: Disable password access through SSH
   lineinfile: dest=/etc/ssh/sshd_config regexp="^PasswordAuthentication" state=present line="PasswordAuthentication no"
   notify: restart sshd
@@ -46,6 +45,10 @@
 - name: Setup Public Keys
   copy: src={{ item }}-id_rsa.pub dest=/home/{{ item }}/.ssh/authorized_keys owner={{ item }} group={{ item }} mode=750
   with_items: "{{local_admins}}"
+
+- name: Copy ntp.conf file into place
+  copy: src=ntp.conf dest=/etc/ntp.conf owner=root group=root mode=644 backup=yes
+  notify: restart ntpd
 
 - name: Check Current Timezone Symlink
   stat: path=/etc/localtime

--- a/ansible/roles/iptables/files/iptables
+++ b/ansible/roles/iptables/files/iptables
@@ -1,10 +1,13 @@
-*filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
 -A INPUT -p tcp -m tcp --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+-A INPUT -i lo -p udp --dport 123 -j ACCEPT
+-A INPUT -p udp --sport 123:123 -m state --state ESTABLISHED -j ACCEPT
 -A INPUT -j DROP
 -A FORWARD -j DROP
 -A OUTPUT -p tcp -m tcp --sport 22 -m conntrack --ctstate ESTABLISHED -j ACCEPT
+-A OUTPUT -o lo -p udp --sport 123 -j ACCEPT
+-A OUTPUT -p udp --dport 123:123 -m state --state NEW,ESTABLISHED -j ACCEPT
 -A OUTPUT -j DROP
 COMMIT

--- a/ansible/roles/iptables/handlers/main.yml
+++ b/ansible/roles/iptables/handlers/main.yml
@@ -1,2 +1,5 @@
-- name: restart notify
+- name: restart iptables
   service: name=iptables state=restarted enabled=yes
+
+- name: restart ip6tables
+  service: name=ip6tables state=restarted enabled=yes

--- a/ansible/roles/iptables/tasks/main.yml
+++ b/ansible/roles/iptables/tasks/main.yml
@@ -4,3 +4,10 @@
 
 - name: Enable IP Tables Service
   service: name=iptables enabled=yes
+
+- name: Put IP6 Tables Config in Place
+  copy: src=iptables dest=/etc/sysconfig/ip6tables owner=root group=root mode=644
+  notify: restart ip6tables
+
+- name: Enable IP6 Tables Service
+  service: name=ip6tables enabled=yes 


### PR DESCRIPTION
Cover both IPv4 and IPv6 firewall rules, as well as allows NTP traffic which is a pre-requisite for Google Authenticator 2FA auth.
